### PR TITLE
Replace deprecated `set-output` with new `$GITHUB_OUTPUT` var

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -35,6 +35,4 @@ runs:
         [ -n "${{ inputs.signer }}" ] && echo "signer: ${{ inputs.signer }}" >> ~/.signore/config.yaml || true
     - id: get-version
       shell: bash
-      run: |
-        SIGNORE_VERSION=$(signore version)
-        echo "::set-output name=installed-version::$SIGNORE_VERSION"
+      run: echo "installed-version=$(signore version)" >> $GITHUB_OUTPUT


### PR DESCRIPTION
This PR updates the deprecated `set-output` command to remove the deprecation warning from CI runs. [More information](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

<img width="1081" alt="CleanShot 2022-11-25 at 17 01 28@2x" src="https://user-images.githubusercontent.com/45985/204021521-06eedd2b-47f3-40cf-a002-30113fb713cc.png">

Since the name `installed-version` remains unchanged, this change should not break any existing workflows.